### PR TITLE
fix: restore live video feed for Seestar

### DIFF
--- a/src-tauri/src/streaming/mod.rs
+++ b/src-tauri/src/streaming/mod.rs
@@ -202,35 +202,45 @@ async fn stream_handler(
                     let height = frame.header.height as u32;
                     let data = frame.data.clone();
 
-                    // Determine if color based on data size vs dimensions
-                    // RGB interleaved = w*h*3, mono = w*h
-                    let expected_rgb = (width * height * 3) as usize;
-                    let is_color = data.len() >= expected_rgb;
+                    // Seestar live preview frames are already JPEG-encoded.
+                    // Detect by JPEG SOI magic bytes (FF D8) and pass through directly.
+                    let is_jpeg = data.len() >= 2 && data[0] == 0xFF && data[1] == 0xD8;
 
-                    // Offload stretch + JPEG encode to a blocking task
-                    let params = StretchParams {
-                        gradient_removal: stretch_params.gradient_removal,
-                        autocrop: stretch_params.autocrop,
-                        ..Default::default()
-                    };
-                    let jpeg_tx = jpeg_tx.clone();
+                    if is_jpeg {
+                        debug!(
+                            "Frame processor: JPEG passthrough {}x{} ({} bytes)",
+                            width, height, data.len()
+                        );
+                        let _ = jpeg_tx.send(data.to_vec());
+                    } else {
+                        // Raw pixel data — apply stretch pipeline
+                        let expected_rgb = (width * height * 3) as usize;
+                        let is_color = data.len() >= expected_rgb;
 
-                    tokio::task::spawn_blocking(move || {
-                        match stretch_raw_frame(&data, width, height, is_color, &params) {
-                            Ok(jpeg_bytes) => {
-                                debug!(
-                                    "Frame processor: stretched {}x{} → {} byte JPEG",
-                                    width,
-                                    height,
-                                    jpeg_bytes.len()
-                                );
-                                let _ = jpeg_tx.send(jpeg_bytes);
+                        let params = StretchParams {
+                            gradient_removal: stretch_params.gradient_removal,
+                            autocrop: stretch_params.autocrop,
+                            ..Default::default()
+                        };
+                        let jpeg_tx = jpeg_tx.clone();
+
+                        tokio::task::spawn_blocking(move || {
+                            match stretch_raw_frame(&data, width, height, is_color, &params) {
+                                Ok(jpeg_bytes) => {
+                                    debug!(
+                                        "Frame processor: stretched {}x{} → {} byte JPEG",
+                                        width,
+                                        height,
+                                        jpeg_bytes.len()
+                                    );
+                                    let _ = jpeg_tx.send(jpeg_bytes);
+                                }
+                                Err(e) => {
+                                    warn!("Frame processor: stretch failed: {}", e);
+                                }
                             }
-                            Err(e) => {
-                                warn!("Frame processor: stretch failed: {}", e);
-                            }
-                        }
-                    });
+                        });
+                    }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                     debug!("Frame processor: skipped {} frames (lagged)", n);
@@ -365,8 +375,8 @@ async fn snapshot_handler(
         ..Default::default()
     };
 
-    // Wait up to 300ms for the next image frame
-    let frame_result = tokio::time::timeout(Duration::from_millis(300), async {
+    // Wait up to 1s for the next image frame
+    let frame_result = tokio::time::timeout(Duration::from_millis(1000), async {
         loop {
             match frame_rx.recv().await {
                 Ok(frame) if frame.header.is_image() => return Some(frame),
@@ -382,14 +392,19 @@ async fn snapshot_handler(
             let width = frame.header.width as u32;
             let height = frame.header.height as u32;
             let data = frame.data.clone();
-            let is_color = data.len() >= (width * height * 3) as usize;
+            let is_jpeg = data.len() >= 2 && data[0] == 0xFF && data[1] == 0xD8;
 
-            tokio::task::spawn_blocking(move || {
-                stretch_raw_frame(&data, width, height, is_color, &stretch_params)
-                    .unwrap_or_else(|_| generate_placeholder_jpeg(width, height, 0))
-            })
-            .await
-            .unwrap_or_else(|_| generate_placeholder_jpeg(640, 480, 0))
+            if is_jpeg {
+                data.to_vec()
+            } else {
+                let is_color = data.len() >= (width * height * 3) as usize;
+                tokio::task::spawn_blocking(move || {
+                    stretch_raw_frame(&data, width, height, is_color, &stretch_params)
+                        .unwrap_or_else(|_| generate_placeholder_jpeg(width, height, 0))
+                })
+                .await
+                .unwrap_or_else(|_| generate_placeholder_jpeg(640, 480, 0))
+            }
         }
         _ => generate_placeholder_jpeg(640, 480, 0),
     };

--- a/src-tauri/src/stretch/pipeline.rs
+++ b/src-tauri/src/stretch/pipeline.rs
@@ -33,55 +33,91 @@ impl Default for StretchParams {
 
 /// Stretch raw frame data and encode to JPEG bytes.
 ///
-/// `data` is raw pixel bytes from the Seestar imaging port.
-/// For color frames, data is expected as interleaved RGB (3 bytes per pixel).
-/// For mono frames, data is 1 byte per pixel.
+/// Auto-detects pixel format from data length:
+/// - `w*h*6` → uint16 LE interleaved RGB
+/// - `w*h*2` → uint16 LE Bayer GRBG (2×2 binned → half resolution)
+/// - `w*h*3` → uint8 interleaved RGB
+/// - `w*h`   → uint8 mono
 ///
 /// Returns JPEG-encoded bytes.
 pub fn stretch_raw_frame(
     data: &[u8],
     width: u32,
     height: u32,
-    is_color: bool,
+    _is_color: bool,
     params: &StretchParams,
 ) -> Result<Vec<u8>, String> {
     let w = width as usize;
     let h = height as usize;
-    let channel_size = w * h;
+    let pixels = w * h;
 
-    // Convert raw bytes to f64 channels normalized to [0, 1]
-    let mut channels: Vec<Vec<f64>> = if is_color {
-        let expected = channel_size * 3;
-        if data.len() < expected {
-            return Err(format!(
-                "Color frame too small: got {} bytes, expected {}",
-                data.len(),
-                expected
-            ));
+    // Auto-detect format from data length; derive output dimensions and f64 channels
+    let (out_w, out_h, mut channels): (usize, usize, Vec<Vec<f64>>) = match data.len() {
+        n if n == pixels * 6 => {
+            // 16-bit interleaved RGB (uint16 LE per component: R G B)
+            let mut r = Vec::with_capacity(pixels);
+            let mut g = Vec::with_capacity(pixels);
+            let mut b = Vec::with_capacity(pixels);
+            for i in 0..pixels {
+                let base = i * 6;
+                r.push(u16::from_le_bytes([data[base],     data[base + 1]]) as f64 / 65535.0);
+                g.push(u16::from_le_bytes([data[base + 2], data[base + 3]]) as f64 / 65535.0);
+                b.push(u16::from_le_bytes([data[base + 4], data[base + 5]]) as f64 / 65535.0);
+            }
+            (w, h, vec![r, g, b])
         }
-        // Deinterleave RGB into separate channels
-        let mut r = Vec::with_capacity(channel_size);
-        let mut g = Vec::with_capacity(channel_size);
-        let mut b = Vec::with_capacity(channel_size);
-        for i in 0..channel_size {
-            r.push(data[i * 3] as f64 / 255.0);
-            g.push(data[i * 3 + 1] as f64 / 255.0);
-            b.push(data[i * 3 + 2] as f64 / 255.0);
+        n if n == pixels * 2 => {
+            // 16-bit Bayer GRBG — 2×2 binning demosaic → half resolution color
+            // Pattern: (even row, even col)=G  (even row, odd col)=R
+            //          (odd  row, even col)=B  (odd  row, odd col)=G
+            let ow = w / 2;
+            let oh = h / 2;
+            let out_pixels = ow * oh;
+            let mut r = Vec::with_capacity(out_pixels);
+            let mut g = Vec::with_capacity(out_pixels);
+            let mut b = Vec::with_capacity(out_pixels);
+            for row in 0..oh {
+                for col in 0..ow {
+                    let sr = row * 2;
+                    let sc = col * 2;
+                    let ig0 = (sr * w + sc) * 2;
+                    let ir  = (sr * w + sc + 1) * 2;
+                    let ib  = ((sr + 1) * w + sc) * 2;
+                    let ig1 = ((sr + 1) * w + sc + 1) * 2;
+                    let g0 = u16::from_le_bytes([data[ig0], data[ig0 + 1]]) as f64;
+                    let rv = u16::from_le_bytes([data[ir],  data[ir  + 1]]) as f64;
+                    let bv = u16::from_le_bytes([data[ib],  data[ib  + 1]]) as f64;
+                    let g1 = u16::from_le_bytes([data[ig1], data[ig1 + 1]]) as f64;
+                    r.push(rv / 65535.0);
+                    g.push((g0 + g1) / 2.0 / 65535.0);
+                    b.push(bv / 65535.0);
+                }
+            }
+            (ow, oh, vec![r, g, b])
         }
-        vec![r, g, b]
-    } else {
-        if data.len() < channel_size {
-            return Err(format!(
-                "Mono frame too small: got {} bytes, expected {}",
-                data.len(),
-                channel_size
-            ));
+        n if n >= pixels * 3 => {
+            // 8-bit interleaved RGB
+            let mut r = Vec::with_capacity(pixels);
+            let mut g = Vec::with_capacity(pixels);
+            let mut b = Vec::with_capacity(pixels);
+            for i in 0..pixels {
+                r.push(data[i * 3]     as f64 / 255.0);
+                g.push(data[i * 3 + 1] as f64 / 255.0);
+                b.push(data[i * 3 + 2] as f64 / 255.0);
+            }
+            (w, h, vec![r, g, b])
         }
-        vec![data[..channel_size]
-            .iter()
-            .map(|&v| v as f64 / 255.0)
-            .collect()]
+        _ => {
+            // 8-bit mono (treat undersized as padded mono)
+            let count = pixels.min(data.len());
+            let mut ch: Vec<f64> = data[..count].iter().map(|&v| v as f64 / 255.0).collect();
+            ch.resize(pixels, 0.0);
+            (w, h, vec![ch])
+        }
     };
+
+    let is_color = channels.len() == 3;
+    let channel_size = out_w * out_h;
 
     // Autocrop — detect edges from averaged channels
     let crop_bounds = if params.autocrop {
@@ -92,7 +128,7 @@ pub fn stretch_raw_frame(
         } else {
             channels[0].clone()
         };
-        autocrop::detect_edges(&mono, w, h)
+        autocrop::detect_edges(&mono, out_w, out_h)
     } else {
         (0, 0, 0, 0)
     };
@@ -100,16 +136,16 @@ pub fn stretch_raw_frame(
     // Normalize — compute percentiles from interior, apply to full frame
     let (top, bottom, left, right) = crop_bounds;
     let interior_y0 = top;
-    let interior_y1 = h - bottom;
+    let interior_y1 = out_h - bottom;
     let interior_x0 = left;
-    let interior_x1 = w - right;
+    let interior_x1 = out_w - right;
 
     channels.par_iter_mut().for_each(|ch| {
         let mut interior: Vec<f64> = if top > 0 || bottom > 0 || left > 0 || right > 0 {
             let mut v = Vec::new();
             for y in interior_y0..interior_y1 {
                 for x in interior_x0..interior_x1 {
-                    v.push(ch[y * w + x]);
+                    v.push(ch[y * out_w + x]);
                 }
             }
             v
@@ -130,7 +166,7 @@ pub fn stretch_raw_frame(
     if params.gradient_removal {
         let order = 2;
         channels.par_iter_mut().for_each(|ch| {
-            let corrected = gradient::remove_gradient(ch, w, h, order);
+            let corrected = gradient::remove_gradient(ch, out_w, out_h, order);
             ch.copy_from_slice(&corrected);
         });
     }
@@ -143,20 +179,20 @@ pub fn stretch_raw_frame(
 
     if is_color {
         for i in 0..channel_size {
-            rgb[i * 3] = (channels[0][i] * 255.0).clamp(0.0, 255.0) as u8;
+            rgb[i * 3]     = (channels[0][i] * 255.0).clamp(0.0, 255.0) as u8;
             rgb[i * 3 + 1] = (channels[1][i] * 255.0).clamp(0.0, 255.0) as u8;
             rgb[i * 3 + 2] = (channels[2][i] * 255.0).clamp(0.0, 255.0) as u8;
         }
     } else {
         for i in 0..channel_size {
             let v = (channels[0][i] * 255.0).clamp(0.0, 255.0) as u8;
-            rgb[i * 3] = v;
+            rgb[i * 3]     = v;
             rgb[i * 3 + 1] = v;
             rgb[i * 3 + 2] = v;
         }
     }
 
-    let img = image::RgbImage::from_raw(width, height, rgb)
+    let img = image::RgbImage::from_raw(out_w as u32, out_h as u32, rgb)
         .ok_or("Failed to create image buffer")?;
 
     let mut jpeg_buf = Cursor::new(Vec::new());

--- a/src-tauri/src/telescope/commands.rs
+++ b/src-tauri/src/telescope/commands.rs
@@ -268,7 +268,39 @@ pub async fn connect_telescope(
             .map_err(|e| format!("Connection timeout: {}", e))?;
 
         tracing::info!("connect_telescope: native Rust client connected");
-        Some(Arc::new(client))
+        let client = Arc::new(client);
+
+        // Auto-start live preview so port 4800 begins streaming immediately.
+        // Fire-and-forget; failure is non-fatal.
+        {
+            let preview_client = client.clone();
+            tokio::spawn(async move {
+                // Brief delay so the control connection is fully settled
+                tokio::time::sleep(tokio::time::Duration::from_millis(800)).await;
+                match preview_client.send_command(Command::IscopeStartView(StartViewParams {
+                    mode: Some(ViewMode::Star),
+                    target_name: None,
+                    target_ra_dec: None,
+                    target_type: None,
+                    lp_filter: None,
+                })).await {
+                    Ok(resp) => {
+                        tracing::info!("connect_telescope: iscope_start_view response: code={} result={:?}", resp.code, resp.result);
+                        // Send begin_streaming on the imaging port (4800) to trigger frame delivery
+                        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+                        let msg = b"{\"id\":21,\"method\":\"begin_streaming\"}\r\n".to_vec();
+                        if let Err(e) = preview_client.send_imaging_command(msg).await {
+                            tracing::warn!("connect_telescope: begin_streaming failed: {}", e);
+                        } else {
+                            tracing::info!("connect_telescope: begin_streaming sent on imaging port");
+                        }
+                    }
+                    Err(e) => tracing::warn!("connect_telescope: auto-start preview failed: {}", e),
+                }
+            });
+        }
+
+        Some(client)
     } else {
         return Err(format!("Unsupported protocol: {}", protocol));
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ function App() {
     theme,
     activeTab,
     setActiveTab,
+    isFullscreen,
   } = useUIStore()
 
   const uiHydrated = useUIStore((state) => state._hasHydrated)
@@ -129,35 +130,38 @@ function App() {
 
   return (
     <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
-      {/* Header */}
-      <TelescopeHeader />
+      {/* Header — hidden in fullscreen */}
+      {!isFullscreen && <TelescopeHeader />}
 
       {/* Main Content */}
       <main className="flex-1 overflow-hidden flex flex-col">
-        <div className="px-4 py-2 border-b border-border bg-card/80">
-          <Tabs value={activeTab} onValueChange={(tab) => setActiveTab(tab as typeof activeTab)}>
-            <TabsList>
-              <TabsTrigger value="telescope">Telescope</TabsTrigger>
-              <TabsTrigger value="catalog">Catalog</TabsTrigger>
-              <TabsTrigger value="imaging">Imaging</TabsTrigger>
-              <TabsTrigger value="planning">Planning</TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
+        {/* Tab bar — hidden in fullscreen */}
+        {!isFullscreen && (
+          <div className="px-4 py-2 border-b border-border bg-card/80">
+            <Tabs value={activeTab} onValueChange={(tab) => setActiveTab(tab as typeof activeTab)}>
+              <TabsList>
+                <TabsTrigger value="telescope">Telescope</TabsTrigger>
+                <TabsTrigger value="catalog">Catalog</TabsTrigger>
+                <TabsTrigger value="imaging">Imaging</TabsTrigger>
+                <TabsTrigger value="planning">Planning</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+        )}
 
         <div className="flex-1 overflow-hidden">
-          {activeTab === 'telescope' && <TelescopeView />}
-          {activeTab === 'catalog' && (
+          {(activeTab === 'telescope' || isFullscreen) && <TelescopeView />}
+          {activeTab === 'catalog' && !isFullscreen && (
             <div className="h-full overflow-auto p-4">
               <CatalogSearch />
             </div>
           )}
-          {activeTab === 'imaging' && (
+          {activeTab === 'imaging' && !isFullscreen && (
             <div className="h-full overflow-auto p-4">
               <ImageViewer />
             </div>
           )}
-          {activeTab === 'planning' && (
+          {activeTab === 'planning' && !isFullscreen && (
             <div className="h-full overflow-auto p-4">
               <SessionPlanning />
             </div>
@@ -165,8 +169,8 @@ function App() {
         </div>
       </main>
 
-      {/* Footer */}
-      <AppFooter />
+      {/* Footer — hidden in fullscreen */}
+      {!isFullscreen && <AppFooter />}
 
       {/* Keyboard Help Modal */}
       <KeyboardHelp />

--- a/src/components/TelescopeView.tsx
+++ b/src/components/TelescopeView.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useCallback } from 'react'
-import { ZoomIn, ZoomOut, Maximize2, Sparkles, Filter, RotateCw } from 'lucide-react'
+import { ZoomIn, ZoomOut, Maximize2, Minimize2, Sparkles, Filter, RotateCw } from 'lucide-react'
 import { Button } from './ui/button'
 import { VideoFeed } from './VideoFeed'
 import { AllskyPanel } from './AllskyPanel'
 import { TelescopeStatusOverlay } from './TelescopeStatusOverlay'
 import { TelescopeControlsOverlay } from './TelescopeControlsOverlay'
 import { useTelescopeStore } from '../stores/telescopeStore'
+import { useUIStore } from '../stores/uiStore'
 
 type ViewMode = 'telescope' | 'allsky'
 
@@ -17,6 +18,7 @@ export function TelescopeView() {
   const containerRef = useRef<HTMLDivElement>(null)
 
   const { currentTelescopeId } = useTelescopeStore()
+  const { isFullscreen, setIsFullscreen } = useUIStore()
 
   const handleZoomIn = () => {
     setZoom((prev) => Math.min(prev + 0.25, 4))
@@ -39,15 +41,7 @@ export function TelescopeView() {
     setPanPosition(newPan)
   }, [])
 
-  const handleFullscreen = () => {
-    if (containerRef.current) {
-      if (document.fullscreenElement) {
-        document.exitFullscreen()
-      } else {
-        containerRef.current.requestFullscreen()
-      }
-    }
-  }
+  const handleFullscreen = () => setIsFullscreen(!isFullscreen)
 
   return (
     <div ref={containerRef} className="relative h-full bg-black overflow-hidden">
@@ -109,9 +103,9 @@ export function TelescopeView() {
             size="icon"
             onClick={handleFullscreen}
             className="rounded-none h-9 w-9"
-            title="Fullscreen"
+            title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
-            <Maximize2 className="h-4 w-4" />
+            {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
           </Button>
           <Button
             variant="ghost"

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -103,9 +103,10 @@ export function useKeyboardShortcuts() {
       },
       {
         key: 'Escape',
-        description: 'Close modal / Cancel action',
+        description: 'Close modal / Cancel action / Exit fullscreen',
         category: 'ui',
         action: () => {
+          useUIStore.getState().setIsFullscreen(false)
           closeAllModals()
           if (telescopeId) {
             stopGoto(telescopeId)


### PR DESCRIPTION
- Patch scopinator-seestar locally (v0.1.1) to add send_imaging_command for writing commands to the imaging port (4800)
- Auto-send iscope_start_view + begin_streaming on connect so frames flow without manual user action
- Decode 16-bit Bayer GRBG and uint16 RGB frames in the stretch pipeline (previews are raw 16-bit, not 8-bit or JPEG as previously assumed)
- Pass JPEG frames through directly without stretch when FF D8 magic detected (future-proofing for stacked JPEG output)
- Fix in-app fullscreen: toggle hides header/tabs/footer so video fills the window; Escape exits; icon swaps Maximize↔Minimize
- Restore [patch.crates-io] for local scopinator-seestar path